### PR TITLE
docs: fix ginkgo version in create operator with operator-sdk

### DIFF
--- a/08-create-operator-with-operator-sdk/02-memcached-operator/README.md
+++ b/08-create-operator-with-operator-sdk/02-memcached-operator/README.md
@@ -452,18 +452,18 @@ git add . && git commit -m "4.1. [Controller] Fetch the Memcached instance"
     1. Change `spec.size` in `config/samples/cache_v1alpha1_memcached.yaml` to 3 and apply a `Memcached` (CR).
 
     	```yaml
-	apiVersion: cache.example.com/v1alpha1
-	kind: Memcached
-	metadata:
-	  labels:
-	    app.kubernetes.io/name: memcached
-	    app.kubernetes.io/instance: memcached-sample
-	    app.kubernetes.io/part-of: memcached-operator
-	    app.kubernetes.io/managed-by: kustomize
-	    app.kubernetes.io/created-by: memcached-operator
-	  name: memcached-sample
-	spec:
-	  size: 2
+        apiVersion: cache.example.com/v1alpha1
+        kind: Memcached
+        metadata:
+          labels:
+            app.kubernetes.io/name: memcached
+            app.kubernetes.io/instance: memcached-sample
+            app.kubernetes.io/part-of: memcached-operator
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/created-by: memcached-operator
+          name: memcached-sample
+        spec:
+          size: 2
 	```
 
         ```bash

--- a/08-create-operator-with-operator-sdk/02-memcached-operator/README.md
+++ b/08-create-operator-with-operator-sdk/02-memcached-operator/README.md
@@ -449,7 +449,23 @@ git add . && git commit -m "4.1. [Controller] Fetch the Memcached instance"
         ```bash
         make run
         ```
-    1. Change `spec.size` to 3 and apply a `Memcached` (CR).
+    1. Change `spec.size` in `config/samples/cache_v1alpha1_memcached.yaml` to 3 and apply a `Memcached` (CR).
+
+    	```yaml
+	apiVersion: cache.example.com/v1alpha1
+	kind: Memcached
+	metadata:
+	  labels:
+	    app.kubernetes.io/name: memcached
+	    app.kubernetes.io/instance: memcached-sample
+	    app.kubernetes.io/part-of: memcached-operator
+	    app.kubernetes.io/managed-by: kustomize
+	    app.kubernetes.io/created-by: memcached-operator
+	  name: memcached-sample
+	spec:
+	  size: 2
+	```
+
         ```bash
         kubectl apply -f config/samples/cache_v1alpha1_memcached.yaml
         ```
@@ -829,7 +845,7 @@ Create `controllers/memcached_controller_test.go`
 package controllers
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/08-create-operator-with-operator-sdk/02-memcached-operator/README.md
+++ b/08-create-operator-with-operator-sdk/02-memcached-operator/README.md
@@ -463,7 +463,7 @@ git add . && git commit -m "4.1. [Controller] Fetch the Memcached instance"
             app.kubernetes.io/created-by: memcached-operator
           name: memcached-sample
         spec:
-          size: 2
+          size: 3
 	```
 
         ```bash


### PR DESCRIPTION
## Why
- operator-sdk uses ginkgo/v2 with [v1.25.0](https://github.com/operator-framework/operator-sdk/releases/tag/v1.25.0) or later

## Ref
- https://github.com/nakamasato/memcached-operator/pull/33